### PR TITLE
Fix data license to use the only allowed value: CC0-1.0

### DIFF
--- a/docs/sbom.md
+++ b/docs/sbom.md
@@ -152,7 +152,7 @@ The following snippet shows a minimal SBOM document:
     ```json
     {
       "spdxVersion": "SPDX-2.3",// (1)!
-      "dataLicense": "CC-BY-4.0",// (2)!
+      "dataLicense": "CC0-1.0",// (2)!
       "SPDXID": "SPDXRef-DOCUMENT",// (3)!
       "creationInfo": {
         "created": "2006-08-14T02:34:56+00:00",
@@ -170,8 +170,7 @@ The following snippet shows a minimal SBOM document:
 
     1. SPDX version 2.3 as described at [https://spdx.github.io/spdx-spec/v2.3/](https://spdx.github.io/spdx-spec/v2.3/).
 
-    2. All Red Hat security data is published under the
-       [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/).
+    2. The CC0-1.0 license is required by the SPDX specification.
 
     3. [`SPDXID`](https://spdx.github.io/spdx-spec/v2.3/document-creation-information/#63-spdx-identifier-field)
        must be set to `SPDXRef-DOCUMENT`.

--- a/sbom/examples/container_image/build/kernel-module-management-operator-container-1.1.2-25.spdx.json
+++ b/sbom/examples/container_image/build/kernel-module-management-operator-container-1.1.2-25.spdx.json
@@ -1,6 +1,6 @@
 {
   "spdxVersion": "SPDX-2.3",
-  "dataLicense": "CC-BY-4.0",
+  "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
     "created": "2006-08-14T02:34:56+00:00",

--- a/sbom/examples/container_image/build/kernel-module-management-operator-container-1.1.2-25_amd64.spdx.json
+++ b/sbom/examples/container_image/build/kernel-module-management-operator-container-1.1.2-25_amd64.spdx.json
@@ -1,6 +1,6 @@
 {
   "spdxVersion": "SPDX-2.3",
-  "dataLicense": "CC-BY-4.0",
+  "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
     "created": "2006-08-14T02:34:56+00:00",

--- a/sbom/examples/container_image/build/kernel-module-management-operator-container-1.1.2-25_arm64.spdx.json
+++ b/sbom/examples/container_image/build/kernel-module-management-operator-container-1.1.2-25_arm64.spdx.json
@@ -1,6 +1,6 @@
 {
   "spdxVersion": "SPDX-2.3",
-  "dataLicense": "CC-BY-4.0",
+  "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
     "created": "2006-08-14T02:34:56+00:00",

--- a/sbom/examples/container_image/build/kernel-module-management-operator-container-1.1.2-25_ppc64le.spdx.json
+++ b/sbom/examples/container_image/build/kernel-module-management-operator-container-1.1.2-25_ppc64le.spdx.json
@@ -1,6 +1,6 @@
 {
   "spdxVersion": "SPDX-2.3",
-  "dataLicense": "CC-BY-4.0",
+  "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
     "created": "2006-08-14T02:34:56+00:00",

--- a/sbom/examples/container_image/build/ubi9-micro-container-9.4-6.1716471860.spdx.json
+++ b/sbom/examples/container_image/build/ubi9-micro-container-9.4-6.1716471860.spdx.json
@@ -1,6 +1,6 @@
 {
   "spdxVersion": "SPDX-2.3",
-  "dataLicense": "CC-BY-4.0",
+  "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
     "created": "2006-08-14T02:34:56+00:00",

--- a/sbom/examples/container_image/build/ubi9-micro-container-9.4-6.1716471860_amd64.spdx.json
+++ b/sbom/examples/container_image/build/ubi9-micro-container-9.4-6.1716471860_amd64.spdx.json
@@ -1,6 +1,6 @@
 {
   "spdxVersion": "SPDX-2.3",
-  "dataLicense": "CC-BY-4.0",
+  "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
     "created": "2006-08-14T02:34:56+00:00",

--- a/sbom/examples/container_image/build/ubi9-micro-container-9.4-6.1716471860_arm64.spdx.json
+++ b/sbom/examples/container_image/build/ubi9-micro-container-9.4-6.1716471860_arm64.spdx.json
@@ -1,6 +1,6 @@
 {
   "spdxVersion": "SPDX-2.3",
-  "dataLicense": "CC-BY-4.0",
+  "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
     "created": "2006-08-14T02:34:56+00:00",

--- a/sbom/examples/container_image/build/ubi9-micro-container-9.4-6.1716471860_ppc64le.spdx.json
+++ b/sbom/examples/container_image/build/ubi9-micro-container-9.4-6.1716471860_ppc64le.spdx.json
@@ -1,6 +1,6 @@
 {
   "spdxVersion": "SPDX-2.3",
-  "dataLicense": "CC-BY-4.0",
+  "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
     "created": "2006-08-14T02:34:56+00:00",

--- a/sbom/examples/container_image/build/ubi9-micro-container-9.4-6.1716471860_s390x.spdx.json
+++ b/sbom/examples/container_image/build/ubi9-micro-container-9.4-6.1716471860_s390x.spdx.json
@@ -1,6 +1,6 @@
 {
   "spdxVersion": "SPDX-2.3",
-  "dataLicense": "CC-BY-4.0",
+  "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
     "created": "2006-08-14T02:34:56+00:00",

--- a/sbom/examples/container_image/release/from_catalog.py
+++ b/sbom/examples/container_image/release/from_catalog.py
@@ -59,7 +59,7 @@ def create_sbom(image_id, root_package, packages, rel_type, other_pkgs=None, oth
 
     spdx = {
         "spdxVersion": "SPDX-2.3",
-        "dataLicense": "CC-BY-4.0",
+        "dataLicense": "CC0-1.0",
         "SPDXID": "SPDXRef-DOCUMENT",
         "creationInfo": {
             "created": "2006-08-14T02:34:56+00:00",

--- a/sbom/examples/container_image/release/kernel-module-management-operator-container-1.1.2-25.spdx.json
+++ b/sbom/examples/container_image/release/kernel-module-management-operator-container-1.1.2-25.spdx.json
@@ -1,6 +1,6 @@
 {
   "spdxVersion": "SPDX-2.3",
-  "dataLicense": "CC-BY-4.0",
+  "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
     "created": "2006-08-14T02:34:56+00:00",

--- a/sbom/examples/container_image/release/kernel-module-management-operator-container-1.1.2-25_amd64.spdx.json
+++ b/sbom/examples/container_image/release/kernel-module-management-operator-container-1.1.2-25_amd64.spdx.json
@@ -1,6 +1,6 @@
 {
   "spdxVersion": "SPDX-2.3",
-  "dataLicense": "CC-BY-4.0",
+  "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
     "created": "2006-08-14T02:34:56+00:00",

--- a/sbom/examples/container_image/release/kernel-module-management-operator-container-1.1.2-25_arm64.spdx.json
+++ b/sbom/examples/container_image/release/kernel-module-management-operator-container-1.1.2-25_arm64.spdx.json
@@ -1,6 +1,6 @@
 {
   "spdxVersion": "SPDX-2.3",
-  "dataLicense": "CC-BY-4.0",
+  "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
     "created": "2006-08-14T02:34:56+00:00",

--- a/sbom/examples/container_image/release/kernel-module-management-operator-container-1.1.2-25_ppc64le.spdx.json
+++ b/sbom/examples/container_image/release/kernel-module-management-operator-container-1.1.2-25_ppc64le.spdx.json
@@ -1,6 +1,6 @@
 {
   "spdxVersion": "SPDX-2.3",
-  "dataLicense": "CC-BY-4.0",
+  "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
     "created": "2006-08-14T02:34:56+00:00",

--- a/sbom/examples/container_image/release/ubi9-micro-container-9.4-6.1716471860.spdx.json
+++ b/sbom/examples/container_image/release/ubi9-micro-container-9.4-6.1716471860.spdx.json
@@ -1,6 +1,6 @@
 {
   "spdxVersion": "SPDX-2.3",
-  "dataLicense": "CC-BY-4.0",
+  "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
     "created": "2006-08-14T02:34:56+00:00",

--- a/sbom/examples/container_image/release/ubi9-micro-container-9.4-6.1716471860_amd64.spdx.json
+++ b/sbom/examples/container_image/release/ubi9-micro-container-9.4-6.1716471860_amd64.spdx.json
@@ -1,6 +1,6 @@
 {
   "spdxVersion": "SPDX-2.3",
-  "dataLicense": "CC-BY-4.0",
+  "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
     "created": "2006-08-14T02:34:56+00:00",

--- a/sbom/examples/container_image/release/ubi9-micro-container-9.4-6.1716471860_arm64.spdx.json
+++ b/sbom/examples/container_image/release/ubi9-micro-container-9.4-6.1716471860_arm64.spdx.json
@@ -1,6 +1,6 @@
 {
   "spdxVersion": "SPDX-2.3",
-  "dataLicense": "CC-BY-4.0",
+  "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
     "created": "2006-08-14T02:34:56+00:00",

--- a/sbom/examples/container_image/release/ubi9-micro-container-9.4-6.1716471860_ppc64le.spdx.json
+++ b/sbom/examples/container_image/release/ubi9-micro-container-9.4-6.1716471860_ppc64le.spdx.json
@@ -1,6 +1,6 @@
 {
   "spdxVersion": "SPDX-2.3",
-  "dataLicense": "CC-BY-4.0",
+  "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
     "created": "2006-08-14T02:34:56+00:00",

--- a/sbom/examples/container_image/release/ubi9-micro-container-9.4-6.1716471860_s390x.spdx.json
+++ b/sbom/examples/container_image/release/ubi9-micro-container-9.4-6.1716471860_s390x.spdx.json
@@ -1,6 +1,6 @@
 {
   "spdxVersion": "SPDX-2.3",
-  "dataLicense": "CC-BY-4.0",
+  "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
     "created": "2006-08-14T02:34:56+00:00",

--- a/sbom/examples/product/create_product_sbom.py
+++ b/sbom/examples/product/create_product_sbom.py
@@ -46,7 +46,7 @@ def create_spdx():
     fname = name_short + ".spdx.json"
     sbom = {
         "spdxVersion": "SPDX-2.3",
-        "dataLicense": "CC-BY-4.0",
+        "dataLicense": "CC0-1.0",
         "SPDXID": "SPDXRef-DOCUMENT",
         "creationInfo": {
             "created": "2006-08-14T02:34:56Z",

--- a/sbom/examples/product/rhel-9.2-eus.spdx.json
+++ b/sbom/examples/product/rhel-9.2-eus.spdx.json
@@ -1,6 +1,6 @@
 {
   "spdxVersion": "SPDX-2.3",
-  "dataLicense": "CC-BY-4.0",
+  "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
     "created": "2006-08-14T02:34:56+00:00",

--- a/sbom/examples/rpm/build/from-koji.py
+++ b/sbom/examples/rpm/build/from-koji.py
@@ -417,7 +417,7 @@ packages.extend([package for arch in pkgs_by_arch for package in pkgs_by_arch[ar
 
 spdx = {
     "spdxVersion": "SPDX-2.3",
-    "dataLicense": "CC-BY-4.0",
+    "dataLicense": "CC0-1.0",
     "SPDXID": "SPDXRef-DOCUMENT",
     "creationInfo": {
         "created": "2006-08-14T02:34:56+00:00",

--- a/sbom/examples/rpm/build/openshift-pipelines-client-1.14.3-11352.el8.spdx.json
+++ b/sbom/examples/rpm/build/openshift-pipelines-client-1.14.3-11352.el8.spdx.json
@@ -1,6 +1,6 @@
 {
   "spdxVersion": "SPDX-2.3",
-  "dataLicense": "CC-BY-4.0",
+  "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
     "created": "2006-08-14T02:34:56+00:00",

--- a/sbom/examples/rpm/build/openssl-3.0.7-18.el9_2.spdx.json
+++ b/sbom/examples/rpm/build/openssl-3.0.7-18.el9_2.spdx.json
@@ -1,6 +1,6 @@
 {
   "spdxVersion": "SPDX-2.3",
-  "dataLicense": "CC-BY-4.0",
+  "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
     "created": "2006-08-14T02:34:56+00:00",

--- a/sbom/examples/rpm/build/poppler-21.01.0-19.el9.spdx.json
+++ b/sbom/examples/rpm/build/poppler-21.01.0-19.el9.spdx.json
@@ -1,6 +1,6 @@
 {
   "spdxVersion": "SPDX-2.3",
-  "dataLicense": "CC-BY-4.0",
+  "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
     "created": "2006-08-14T02:34:56+00:00",

--- a/sbom/examples/rpm/release/openshift-pipelines-client-1.14.3-11352.el8.spdx.json
+++ b/sbom/examples/rpm/release/openshift-pipelines-client-1.14.3-11352.el8.spdx.json
@@ -1,6 +1,6 @@
 {
   "spdxVersion": "SPDX-2.3",
-  "dataLicense": "CC-BY-4.0",
+  "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
     "created": "2006-08-14T02:34:56+00:00",

--- a/sbom/examples/rpm/release/openssl-3.0.7-18.el9_2.spdx.json
+++ b/sbom/examples/rpm/release/openssl-3.0.7-18.el9_2.spdx.json
@@ -1,6 +1,6 @@
 {
   "spdxVersion": "SPDX-2.3",
-  "dataLicense": "CC-BY-4.0",
+  "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
     "created": "2006-08-14T02:34:56+00:00",

--- a/sbom/examples/rpm/release/poppler-21.01.0-19.el9.spdx.json
+++ b/sbom/examples/rpm/release/poppler-21.01.0-19.el9.spdx.json
@@ -1,6 +1,6 @@
 {
   "spdxVersion": "SPDX-2.3",
-  "dataLicense": "CC-BY-4.0",
+  "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
     "created": "2006-08-14T02:34:56+00:00",


### PR DESCRIPTION
Turns out that while the schema doesn't have any restrictions on this field:

https://github.com/RedHatProductSecurity/security-data-guidelines/blob/main/sbom/spdx-2.3-schema.json#L70

The spec actually does:

https://spdx.github.io/spdx-spec/v2.3/document-creation-information/#62-data-license-field

and `CC0-1.0` is the only allowed value ¯\\_(ツ)_/¯