### PR TITLE
Remove bom-ref attributes from the metadata component

### DIFF
--- a/sbom/examples/product/rhel-9.2-eus.cdx.json
+++ b/sbom/examples/product/rhel-9.2-eus.cdx.json
@@ -5,7 +5,6 @@
   "serialNumber": "urn:uuid:337d9115-4e7c-4e76-b389-51f7aed6eba8",
   "metadata": {
     "component": {
-      "bom-ref": "cpe:/a:redhat:rhel_eus:9.2::baseos",
       "type": "operating-system",
       "name": "Red Hat Enterprise Linux",
       "version": "9.2 EUS",

--- a/sbom/examples/product/rhel-9.2-main+eus.cdx.json
+++ b/sbom/examples/product/rhel-9.2-main+eus.cdx.json
@@ -5,7 +5,6 @@
   "serialNumber": "urn:uuid:337d9115-4e7c-4e76-b389-51f7aed6eba8",
   "metadata": {
     "component": {
-      "bom-ref": "cpe:/a:redhat:rhel_eus:9.2::baseos",
       "type": "operating-system",
       "name": "Red Hat Enterprise Linux",
       "version": "9.2 MAIN+EUS",

--- a/sbom/examples/product/rhel-9.4-main+eus.cdx.json
+++ b/sbom/examples/product/rhel-9.4-main+eus.cdx.json
@@ -5,7 +5,6 @@
   "serialNumber": "urn:uuid:337d9115-4e7c-4e76-b389-51f7aed6eba8",
   "metadata": {
     "component": {
-      "bom-ref": "cpe:/o:redhat:enterprise_linux:9::baseos",
       "type": "operating-system",
       "name": "Red Hat Enterprise Linux",
       "version": "9.4 MAIN+EUS",

--- a/sbom/examples/rpm/build/delve-1.7.2-1.module+el8.6.0+12972+ebab5911.cdx.json
+++ b/sbom/examples/rpm/build/delve-1.7.2-1.module+el8.6.0+12972+ebab5911.cdx.json
@@ -5,7 +5,6 @@
   "serialNumber": "urn:uuid:223234df-bb5b-49af-a896-143736f7d806",
   "metadata": {
     "component": {
-      "bom-ref": "pkg:rpm/redhat/delve@1.7.2-1.module+el8.6.0+12972+ebab5911?arch=src&rpmmod=go-toolset:rhel8:8060020250609110611:97d7f71f",
       "type": "library",
       "name": "delve",
       "version": "1.7.2-1.module+el8.6.0+12972+ebab5911",

--- a/sbom/examples/rpm/build/from-koji.py
+++ b/sbom/examples/rpm/build/from-koji.py
@@ -529,6 +529,8 @@ class SBOMBuilder:
             "relationships": self.spdx_relationships,
         }
 
+        copy_of_cdx_root = deepcopy(cdx_root_component)
+        cdx_root_component.pop("bom-ref")
         cdx = {
             "bomFormat": "CycloneDX",
             "specVersion": "1.6",
@@ -549,19 +551,18 @@ class SBOMBuilder:
             },
         }
 
-        copy_of_cdx_root = deepcopy(cdx_root_component)
         copy_of_cdx_root["pedigree"] = {"ancestors": cdx_pedigrees}
         self.cdx_components.append(copy_of_cdx_root)
         cdx["components"] = sorted(self.cdx_components, key=lambda c: c["purl"])
 
         binary_rpm_purls = set()
         for cdx_component in self.cdx_components:
-            if cdx_component["bom-ref"] == cdx_root_component["bom-ref"]:
+            if cdx_component["bom-ref"] == copy_of_cdx_root["bom-ref"]:
                 continue
             binary_rpm_purls.add(cdx_component["purl"])
 
         cdx["dependencies"] = [
-            {"ref": cdx_root_component["bom-ref"], "provides": sorted(list(binary_rpm_purls))}
+            {"ref": copy_of_cdx_root["bom-ref"], "provides": sorted(list(binary_rpm_purls))}
         ]
 
         with open(f"{build_id}.spdx.json", "w") as fp:

--- a/sbom/examples/rpm/build/go-toolset-1.17.13-2.module+el8.6.0+22782+bd95fb4c.cdx.json
+++ b/sbom/examples/rpm/build/go-toolset-1.17.13-2.module+el8.6.0+22782+bd95fb4c.cdx.json
@@ -5,7 +5,6 @@
   "serialNumber": "urn:uuid:223234df-bb5b-49af-a896-143736f7d806",
   "metadata": {
     "component": {
-      "bom-ref": "pkg:rpm/redhat/go-toolset@1.17.13-2.module+el8.6.0+22782+bd95fb4c?arch=src&rpmmod=go-toolset:rhel8:8060020250609110611:97d7f71f",
       "type": "library",
       "name": "go-toolset",
       "version": "1.17.13-2.module+el8.6.0+22782+bd95fb4c",

--- a/sbom/examples/rpm/build/golang-1.17.13-9.module+el8.6.0+23245+b36ba85c.cdx.json
+++ b/sbom/examples/rpm/build/golang-1.17.13-9.module+el8.6.0+23245+b36ba85c.cdx.json
@@ -5,7 +5,6 @@
   "serialNumber": "urn:uuid:223234df-bb5b-49af-a896-143736f7d806",
   "metadata": {
     "component": {
-      "bom-ref": "pkg:rpm/redhat/golang@1.17.13-9.module+el8.6.0+23245+b36ba85c?arch=src&rpmmod=go-toolset:rhel8:8060020250609110611:97d7f71f",
       "type": "library",
       "name": "golang",
       "version": "1.17.13-9.module+el8.6.0+23245+b36ba85c",

--- a/sbom/examples/rpm/build/openshift-pipelines-client-1.14.3-11352.el8.cdx.json
+++ b/sbom/examples/rpm/build/openshift-pipelines-client-1.14.3-11352.el8.cdx.json
@@ -5,7 +5,6 @@
   "serialNumber": "urn:uuid:223234df-bb5b-49af-a896-143736f7d806",
   "metadata": {
     "component": {
-      "bom-ref": "pkg:rpm/redhat/openshift-pipelines-client@1.14.3-11352.el8?arch=src",
       "type": "library",
       "name": "openshift-pipelines-client",
       "version": "1.14.3-11352.el8",

--- a/sbom/examples/rpm/build/openssl-3.0.7-18.el9_2.cdx.json
+++ b/sbom/examples/rpm/build/openssl-3.0.7-18.el9_2.cdx.json
@@ -5,7 +5,6 @@
   "serialNumber": "urn:uuid:223234df-bb5b-49af-a896-143736f7d806",
   "metadata": {
     "component": {
-      "bom-ref": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=src&epoch=1",
       "type": "library",
       "name": "openssl",
       "version": "3.0.7-18.el9_2",

--- a/sbom/examples/rpm/build/poppler-21.01.0-19.el9.cdx.json
+++ b/sbom/examples/rpm/build/poppler-21.01.0-19.el9.cdx.json
@@ -5,7 +5,6 @@
   "serialNumber": "urn:uuid:223234df-bb5b-49af-a896-143736f7d806",
   "metadata": {
     "component": {
-      "bom-ref": "pkg:rpm/redhat/poppler@21.01.0-19.el9?arch=src",
       "type": "library",
       "name": "poppler",
       "version": "21.01.0-19.el9",

--- a/sbom/examples/rpm/build/vim-9.1.083-5.el10.cdx.json
+++ b/sbom/examples/rpm/build/vim-9.1.083-5.el10.cdx.json
@@ -5,7 +5,6 @@
   "serialNumber": "urn:uuid:223234df-bb5b-49af-a896-143736f7d806",
   "metadata": {
     "component": {
-      "bom-ref": "pkg:rpm/redhat/vim@9.1.083-5.el10?arch=src&epoch=2",
       "type": "library",
       "name": "vim",
       "version": "9.1.083-5.el10",

--- a/sbom/examples/rpm/release/delve-1.7.2-1.module+el8.6.0+12972+ebab5911.cdx.json
+++ b/sbom/examples/rpm/release/delve-1.7.2-1.module+el8.6.0+12972+ebab5911.cdx.json
@@ -5,7 +5,6 @@
   "serialNumber": "urn:uuid:223234df-bb5b-49af-a896-143736f7d806",
   "metadata": {
     "component": {
-      "bom-ref": "pkg:rpm/redhat/delve@1.7.2-1.module+el8.6.0+12972+ebab5911?arch=src&rpmmod=go-toolset:rhel8:8060020250609110611:97d7f71f",
       "type": "library",
       "name": "delve",
       "version": "1.7.2-1.module+el8.6.0+12972+ebab5911",

--- a/sbom/examples/rpm/release/go-toolset-1.17.13-2.module+el8.6.0+22782+bd95fb4c.cdx.json
+++ b/sbom/examples/rpm/release/go-toolset-1.17.13-2.module+el8.6.0+22782+bd95fb4c.cdx.json
@@ -5,7 +5,6 @@
   "serialNumber": "urn:uuid:223234df-bb5b-49af-a896-143736f7d806",
   "metadata": {
     "component": {
-      "bom-ref": "pkg:rpm/redhat/go-toolset@1.17.13-2.module+el8.6.0+22782+bd95fb4c?arch=src&rpmmod=go-toolset:rhel8:8060020250609110611:97d7f71f",
       "type": "library",
       "name": "go-toolset",
       "version": "1.17.13-2.module+el8.6.0+22782+bd95fb4c",

--- a/sbom/examples/rpm/release/golang-1.17.13-9.module+el8.6.0+23245+b36ba85c.cdx.json
+++ b/sbom/examples/rpm/release/golang-1.17.13-9.module+el8.6.0+23245+b36ba85c.cdx.json
@@ -5,7 +5,6 @@
   "serialNumber": "urn:uuid:223234df-bb5b-49af-a896-143736f7d806",
   "metadata": {
     "component": {
-      "bom-ref": "pkg:rpm/redhat/golang@1.17.13-9.module+el8.6.0+23245+b36ba85c?arch=src&rpmmod=go-toolset:rhel8:8060020250609110611:97d7f71f",
       "type": "library",
       "name": "golang",
       "version": "1.17.13-9.module+el8.6.0+23245+b36ba85c",

--- a/sbom/examples/rpm/release/openshift-pipelines-client-1.14.3-11352.el8.cdx.json
+++ b/sbom/examples/rpm/release/openshift-pipelines-client-1.14.3-11352.el8.cdx.json
@@ -5,7 +5,6 @@
   "serialNumber": "urn:uuid:223234df-bb5b-49af-a896-143736f7d806",
   "metadata": {
     "component": {
-      "bom-ref": "pkg:rpm/redhat/openshift-pipelines-client@1.14.3-11352.el8?arch=src",
       "type": "library",
       "name": "openshift-pipelines-client",
       "version": "1.14.3-11352.el8",

--- a/sbom/examples/rpm/release/openssl-3.0.7-18.el9_2.cdx.json
+++ b/sbom/examples/rpm/release/openssl-3.0.7-18.el9_2.cdx.json
@@ -5,7 +5,6 @@
   "serialNumber": "urn:uuid:223234df-bb5b-49af-a896-143736f7d806",
   "metadata": {
     "component": {
-      "bom-ref": "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=src&epoch=1",
       "type": "library",
       "name": "openssl",
       "version": "3.0.7-18.el9_2",

--- a/sbom/examples/rpm/release/poppler-21.01.0-19.el9.cdx.json
+++ b/sbom/examples/rpm/release/poppler-21.01.0-19.el9.cdx.json
@@ -5,7 +5,6 @@
   "serialNumber": "urn:uuid:223234df-bb5b-49af-a896-143736f7d806",
   "metadata": {
     "component": {
-      "bom-ref": "pkg:rpm/redhat/poppler@21.01.0-19.el9?arch=src",
       "type": "library",
       "name": "poppler",
       "version": "21.01.0-19.el9",

--- a/sbom/examples/rpm/release/vim-9.1.083-5.el10.cdx.json
+++ b/sbom/examples/rpm/release/vim-9.1.083-5.el10.cdx.json
@@ -5,7 +5,6 @@
   "serialNumber": "urn:uuid:223234df-bb5b-49af-a896-143736f7d806",
   "metadata": {
     "component": {
-      "bom-ref": "pkg:rpm/redhat/vim@9.1.083-5.el10?arch=src&epoch=2",
       "type": "library",
       "name": "vim",
       "version": "9.1.083-5.el10",


### PR DESCRIPTION
Since we replicate the root component as the first element of the `components` array, we can't have two components share the same bom-ref; that would produce an invalid CDX SBOM. The metadata.component thus has it removed and it is only present in the first component.

Fyi, @jasinner @JimFuller-RedHat

See also, https://issues.redhat.com/browse/TC-2606#comment-27421544.